### PR TITLE
Harden nickname validation to reject unsupported characters

### DIFF
--- a/utils/validator.py
+++ b/utils/validator.py
@@ -26,6 +26,7 @@ class NicknameValidator:
     """
     
     # Configuration
+    # Allowed: alphanumeric + a small safe set used by DamaDam profiles
     ALLOWED_SPECIAL = set('@.-_')
     MAX_LENGTH = 50
     MIN_LENGTH = 1
@@ -88,6 +89,20 @@ class NicknameValidator:
         dangerous_found = [c for c in nickname if c in cls.DANGEROUS_CHARS]
         if dangerous_found:
             return False, None, f"Contains dangerous characters: {', '.join(dangerous_found)}"
+
+        # Enforce supported character set
+        invalid_chars = [
+            c for c in nickname
+            if not (c.isalnum() or c in cls.ALLOWED_SPECIAL)
+        ]
+        if invalid_chars:
+            unique_chars = ', '.join(sorted(set(invalid_chars)))
+            return (
+                False,
+                None,
+                f"Contains unsupported characters: {unique_chars}. "
+                "Allowed: letters, digits, @ . - _"
+            )
         
         # Check if it's just special characters (must have at least one alphanumeric)
         if not any(c.isalnum() for c in nickname):


### PR DESCRIPTION
### Motivation
- Prevent invalid or unexpected nickname characters (e.g. punctuation like `!`, `%`) from being accepted and propagated into URL/scraping flows by tightening the validator.

### Description
- Add explicit supported-character enforcement in `NicknameValidator.validate` (file `utils/validator.py`) so nicknames are limited to alphanumeric characters plus `@`, `.`, `-`, and `_`, and return a clear error when unsupported characters are present.

### Testing
- Run `python -m compileall -q .` and `python main.py --help` to ensure no syntax/CLI regressions, and compiled `utils/validator.py` then exercised `NicknameValidator.validate` with representative cases (`user123`, `john_doe`, `has space`, `name!`, `@@@`, `پاک`), all checks passed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879ba556d483318ee63fc95ff9b1ad)